### PR TITLE
Add checkCurrentUserCanUpdateSettings to ConfigContextProvider

### DIFF
--- a/src/ConfigContext.tsx
+++ b/src/ConfigContext.tsx
@@ -101,6 +101,7 @@ const ConfigContextProvider: React.FC<{ children: React.ReactNode }> = ({
     me,
     config_data.restrict_settings,
     config_data.setting_group_ids,
+    checkCurrentUserCanUpdateSettings,
   ]);
 
   const updateValues = (values: Partial<IExtensionConfig>) => {


### PR DESCRIPTION
- Introduced a new prop to the ConfigContextProvider to manage user permissions for updating settings.